### PR TITLE
Support contextual linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,11 +97,6 @@
 					"default": false,
 					"markdownDescription": "Use Vale's CLI instead of Vale Server. (**NOTE**: Some features, such as [Quick Fixes](https://github.com/errata-ai/vale-vscode/pull/4) and [Vocab Management](https://github.com/errata-ai/vale-vscode/pull/4), are only available when using Vale Server.)"
 				},
-				"vale.core.lintContext": {
-					"type": "boolean",
-					"default": false,
-					"markdownDescription": "Only lint the *active* portion of a document (as determined by the cursor position), allowing for efficient on-the-fly linting of large documents."
-				},
 
 				"vale.server.serverURL": {
 					"type": "string",
@@ -112,6 +107,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Offer solutions to alerts using the 'Quick Fix' button."
+				},
+				"vale.server.lintContext": {
+					"type": "number",
+					"default": 0,
+					"markdownDescription": "Only lint the *active* portion of a document (as determined by the cursor position), allowing for efficient on-the-fly linting of large documents. There are three supported values: `-1` (applies to all files), `0` (disabled), `n` (applies to any file with `lines >= n`)."
 				},
 
 				"vale.valeCLI.config": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
 					"default": false,
 					"markdownDescription": "Use Vale's CLI instead of Vale Server. (**NOTE**: Some features, such as [Quick Fixes](https://github.com/errata-ai/vale-vscode/pull/4) and [Vocab Management](https://github.com/errata-ai/vale-vscode/pull/4), are only available when using Vale Server.)"
 				},
+				"vale.core.lintContext": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Only lint the *active* portion of a document (as determined by the cursor position), allowing for efficient on-the-fly linting of large documents."
+				},
 
 				"vale.server.serverURL": {
 					"type": "string",

--- a/src/features/vsTypes.ts
+++ b/src/features/vsTypes.ts
@@ -1,0 +1,32 @@
+/**
+ * A severity from Vale Server.
+ */
+type ValeSeverity = 'suggestion' | 'warning' | 'error';
+
+interface IEditorContext {
+    Content: string;
+    Offset: number;
+}
+
+/**
+ * An Action From Vale.
+ */
+interface IValeActionJSON {
+    readonly Name: string;
+    readonly Params: [string];
+}
+
+/**
+ * An Alert From Vale.
+ */
+interface IValeErrorJSON {
+    readonly Action: IValeActionJSON;
+    readonly Check: string;
+    readonly Match: string;
+    readonly Description: string;
+    readonly Line: number;
+    readonly Link: string;
+    readonly Message: string;
+    readonly Span: [number, number];
+    readonly Severity: ValeSeverity;
+}

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -1,0 +1,228 @@
+import * as path from 'path';
+import * as which from "which";
+import * as fs from 'fs';
+import * as request from 'request-promise-native';
+import { execFile } from "child_process";
+
+import * as vscode from 'vscode';
+import { off } from 'process';
+
+export const readBinaryLocation = () => {
+    const configuration = vscode.workspace.getConfiguration();
+    const customBinaryPath = configuration.get<string>("vale.valeCLI.path");
+    if (customBinaryPath) {
+        return path.normalize(customBinaryPath);
+    }
+    // Assume that the binary is installed globally
+    return which.sync("vale");
+};
+
+export const readFileLocation = () => {
+    const configuration = vscode.workspace.getConfiguration();
+    const customConfigPath = configuration.get<string>("vale.valeCLI.config");
+
+    // Assume that the binary is installed globally
+    return customConfigPath;
+};
+
+/**
+ * Convert a Vale severity string to a code diagnostic severity.
+ *
+ * @param severity The severity to convert
+ */
+export const toSeverity = (severity: ValeSeverity): vscode.DiagnosticSeverity => {
+    switch (severity) {
+        case 'suggestion':
+            return vscode.DiagnosticSeverity.Information;
+        case 'warning':
+            return vscode.DiagnosticSeverity.Warning;
+        case 'error':
+            return vscode.DiagnosticSeverity.Error;
+    }
+};
+
+/**
+ * Create an action title from a given alert and suggestion.
+ *
+ * @param alert The Vale-created alert
+ * @param suggestion The vsengine-calculated suggestion
+ */
+export const toTitle = (alert: IValeErrorJSON, suggestion: string): string => {
+    switch (alert.Action.Name) {
+        case 'remove':
+            return 'Remove \'' + alert.Match + '\'';
+    }
+    return 'Replace with \'' + suggestion + '\'';
+};
+
+/**
+ * Whether a given document is elligible for linting.
+ *
+ * A document is elligible if it's in a supported format and saved to disk.
+ *
+ * @param document The document to check
+ * @return Whether the document is elligible
+ */
+export const isElligibleDocument = (document: vscode.TextDocument): boolean => {
+    if (document.isDirty) {
+        vscode.window.showErrorMessage('Please save the file before linting.');
+        return false;
+    }
+    return vscode.languages.match({ scheme: "file" }, document) > 0;
+};
+
+/**
+ * Convert a Vale error to a code diagnostic.
+ *
+ * @param alert The alert to convert
+ */
+export const toDiagnostic = (
+    alert: IValeErrorJSON,
+    styles: string,
+    backend: string,
+    offset: number
+): vscode.Diagnostic => {
+    const range = new vscode.Range(
+        (alert.Line - 1) + offset,
+        alert.Span[0] - 1,
+        (alert.Line - 1) + offset,
+        alert.Span[1]
+    );
+
+    const diagnostic =
+        new vscode.Diagnostic(range, alert.Message, toSeverity(alert.Severity));
+
+    diagnostic.source = backend;
+    diagnostic.code = alert.Check;
+
+    const name = alert.Check.split('.');
+    const rule = vscode.Uri.file(path.join(styles, name[0], name[1] + '.yml'));
+
+    if (fs.existsSync(rule.fsPath)) {
+        diagnostic.relatedInformation = [new vscode.DiagnosticRelatedInformation(
+            new vscode.Location(rule, new vscode.Position(0, 0)), 'View rule')];
+    }
+    return diagnostic;
+};
+
+/**
+ * Run a command in a given workspace folder and get its standard output.
+ *
+ * If the workspace folder is undefined run the command in the working directory
+ * of the current vscode instance.
+ *
+ * @param folder The workspace
+ * @param command The command array
+ * @return The standard output of the program
+ */
+export const runInWorkspace = (
+    folder: string | undefined,
+    command: ReadonlyArray<string>,
+): Promise<string> =>
+    new Promise((resolve, reject) => {
+        const cwd = folder ? folder : process.cwd();
+        const maxBuffer = 10 * 1024 * 1024; // 10MB buffer for large results
+        execFile(
+            command[0],
+            command.slice(1),
+            { cwd, maxBuffer },
+            (error, stdout) => {
+                if (error) {
+                    // Throw system errors, but do not fail if the command
+                    // fails with a non-zero exit code.
+                    console.error("Command error", command, error);
+                    reject(error);
+                } else {
+                    resolve(stdout);
+                }
+            },
+        );
+    });
+
+const extractParagraph = (editor: vscode.TextEditor): vscode.Range => {
+    let startLine = editor.selection.start.line;
+    let endLine = editor.selection.end.line;
+
+    while (startLine > 0 && !editor.document.lineAt(startLine - 1).isEmptyOrWhitespace) {
+        startLine -= 1;
+    }
+
+    while (endLine < editor.document.lineCount - 1 &&
+        !editor.document.lineAt(endLine + 1).isEmptyOrWhitespace) {
+        endLine += 1;
+    }
+
+    const startCharacter = 0;
+    const endCharacter = editor.document.lineAt(endLine).text.length;
+
+    return new vscode.Range(startLine, startCharacter, endLine, endCharacter);
+};
+
+export const findContext = (): IEditorContext => {
+    const editor = vscode.window.activeTextEditor;
+
+    let context: IEditorContext = {Content: "", Offset: 0};
+    if (!editor) {
+        return context;
+    }
+    const range = extractParagraph(editor);
+
+    context.Content = editor.document.getText(range);
+    context.Offset = range.start.line;
+
+    return context;
+};
+
+export const postFile = async (doc: vscode.TextDocument): Promise<string> => {
+    let server: string = vscode.workspace.getConfiguration().get(
+        'vale.server.serverURL',
+        'http://localhost:7777'
+    );
+    let response: string = "";
+
+    await request
+        .post({
+            uri: server + '/file',
+            qs: {
+                file: doc.fileName,
+                path: path.dirname(doc.fileName)
+            },
+            json: true
+        })
+        .catch((error) => {
+            vscode.window.showErrorMessage(
+                `Vale Server could not connect: ${error}.`);
+        })
+        .then((body) => {
+            response = fs.readFileSync(body.path).toString();
+        });
+
+    return response;
+};
+
+export const postString = async (content: string, ext: string): Promise<string> => {
+    let server: string = vscode.workspace.getConfiguration().get(
+        'vale.server.serverURL',
+        'http://localhost:7777'
+    );
+    let response: string = "";
+
+    await request
+        .post({
+            uri: server + '/vale',
+            qs: {
+                text: content,
+                format: ext
+            },
+            json: false
+        })
+        .catch((error) => {
+            vscode.window.showErrorMessage(
+                `Vale Server could not connect: ${error}.`);
+        })
+        .then((body) => {
+            response = body;
+        });
+
+    return response;
+};

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -226,3 +226,41 @@ export const postString = async (content: string, ext: string): Promise<string> 
 
     return response;
 };
+
+export const getStylesPath = async (usingCLI: boolean): Promise<string> => {
+    const configuration = vscode.workspace.getConfiguration();
+
+    let path: string = "";
+    if (!usingCLI) {
+        let server: string = configuration.get(
+            'vale.server.serverURL',
+            'http://localhost:7777'
+        );
+
+        await request.get({ uri: server + '/path', json: true })
+            .catch((error) => {
+                throw new Error(`Vale Server could not connect: ${error}.`);
+            })
+            .then((body) => {
+                path = body.path;
+            });
+    } else {
+        const binaryLocation = readBinaryLocation();
+        const configLocation = readFileLocation()!;
+
+        const stylesPath: ReadonlyArray<string> = [
+            binaryLocation,
+            "--no-exit",
+            "--config",
+            configLocation,
+            "ls-config"
+        ];
+
+        var configOut = await runInWorkspace(undefined, stylesPath);
+        const configCLI = JSON.parse(configOut);
+
+        path = configCLI.StylesPath;
+    }
+
+    return path;
+}


### PR DESCRIPTION
> NOTE: This isn't ready to merge just yet, but I figured I'd publish what I have so far for discussion purposes.

This PR introduces a new mode, `vale.core.lintContext`, that only lints the paragraph around the user's active cursor.

The motivation behind this feature is LanguageTool, which can be *extremely* slow: On a 3,000 line Markdown file I use for testing, Vale + its Microsoft style takes around 3s. When I enable LanguageTool, the time balloons to around 30s which makes on-the-fly linting impossible (or at least very unpleasant -- I've received a number of complaints about this).

With `vale.core.lintContext` enabled, however, linting large documents becomes practically instantaneous.

---

As far as changes go, I've left the CLI-related code largely untouched for now:

- I created two new files, `vsTypes.ts` and `vsUtils.ts`, in an effort to keep `vsProvider.ts` from becoming too bloated.

- I added an extra argument to `handleJSON`, which is set to 0 for the CLI mode.

I think the mode could be useful for Vale as well, though.