### PR TITLE
Add support for `--minAlertLevel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,5 @@ The extension offers a number of settings and configuration options (_Preference
       "vale.valeCLI.path": "/some/path/to/vale"
     }
     ```
+
+- `vale.valeCLI.minAlertLevel` (default: `inherited`): Defines from which level of errors and above to display in the problems output.

--- a/package.json
+++ b/package.json
@@ -126,7 +126,12 @@
 					"default": null,
 					"markdownDescription": "Absolute path to the Vale binary. The predefined [`${workspaceFolder}`](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) variable can be used to reference a non-global binary. (**NOTE**: On Windows you can use '/' and can omit `.cmd` in the path value.)"
 				},
-
+				"vale.valeCLI.minAlertLevel": {
+					"scope": "resource",
+					"type": "string",
+					"default": null,
+					"markdownDescription": "Sets the minimum alert level to display. This takes precedence over the value set in a configuration file."
+				},
 
 				"vale-server.serverURL": {
 					"type": "string",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
 					"category": "Vale",
 					"when": "!config.vale.core.useCLI"
 				},
-
 				{
 					"command": "vale.addToAccept",
 					"category": "Vale",
@@ -97,7 +96,6 @@
 					"default": false,
 					"markdownDescription": "Use Vale's CLI instead of Vale Server. (**NOTE**: Some features, such as [Quick Fixes](https://github.com/errata-ai/vale-vscode/pull/4) and [Vocab Management](https://github.com/errata-ai/vale-vscode/pull/4), are only available when using Vale Server.)"
 				},
-
 				"vale.server.serverURL": {
 					"type": "string",
 					"default": "http://127.0.0.1:7777",
@@ -113,7 +111,6 @@
 					"default": 0,
 					"markdownDescription": "Only lint the *active* portion of a document (as determined by the cursor position), allowing for efficient on-the-fly linting of large documents. There are three supported values: `-1` (applies to all files), `0` (disabled), `n` (applies to any file with `lines >= n`)."
 				},
-
 				"vale.valeCLI.config": {
 					"scope": "resource",
 					"type": "string",
@@ -141,9 +138,9 @@
 						"Sets `minAlertLevel` to `suggestion`, overriding any configuration files.",
 						"Sets `minAlertLevel` to `warning`, overriding any configuration files.",
 						"Sets `minAlertLevel` to `error`, overriding any configuration files."
-					]
+					],
+					"markdownDescription": "Defines from which level of errors and above to display in the problems output."
 				},
-
 				"vale-server.serverURL": {
 					"type": "string",
 					"default": "http://127.0.0.1:7777",

--- a/package.json
+++ b/package.json
@@ -129,8 +129,19 @@
 				"vale.valeCLI.minAlertLevel": {
 					"scope": "resource",
 					"type": "string",
-					"default": null,
-					"markdownDescription": "Sets the minimum alert level to display. This takes precedence over the value set in a configuration file."
+					"default": "inherited",
+					"enum": [
+						"inherited",
+						"suggestion",
+						"warning",
+						"error"
+					],
+					"markdownEnumDescriptions": [
+						"Inherits the `minAlertLevel` from the active configuration file.",
+						"Sets `minAlertLevel` to `suggestion`, overriding any configuration files.",
+						"Sets `minAlertLevel` to `warning`, overriding any configuration files.",
+						"Sets `minAlertLevel` to `error`, overriding any configuration files."
+					]
 				},
 
 				"vale-server.serverURL": {

--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -100,7 +100,6 @@ export default class ValeServerProvider implements vscode.CodeActionProvider {
           configLocation,
           file.fileName);
 
-        console.log("running", command);
         const stdout = await utils.runInWorkspace(folder, command);
         this.handleJSON(stdout.toString(), file, 0);
         } catch (error) {
@@ -108,7 +107,7 @@ export default class ValeServerProvider implements vscode.CodeActionProvider {
           //
           // TODO: in case (2), how do we unintrusively communicate that we
           // couldn't find a config file?
-          console.log("[Vale] could't find a .vale.ini file; skipping lint.");
+          console.log(`[Vale] runtime error: ${error}`);
         }
     }
 

--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -100,6 +100,7 @@ export default class ValeServerProvider implements vscode.CodeActionProvider {
           configLocation,
           file.fileName);
 
+        console.log("running", command);
         const stdout = await utils.runInWorkspace(folder, command);
         this.handleJSON(stdout.toString(), file, 0);
         } catch (error) {

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -5,7 +5,6 @@ import * as request from 'request-promise-native';
 import { execFile } from "child_process";
 
 import * as vscode from 'vscode';
-import { off } from 'process';
 
 export const readBinaryLocation = (file: vscode.TextDocument) => {
     const configuration = vscode.workspace.getConfiguration();
@@ -145,14 +144,7 @@ export const runInWorkspace = (
             command.slice(1),
             { cwd, maxBuffer },
             (error, stdout) => {
-                if (error) {
-                    // Throw system errors, but do not fail if the command
-                    // fails with a non-zero exit code.
-                    console.error("Command error", command, error);
-                    reject(error);
-                } else {
-                    resolve(stdout);
-                }
+                resolve(stdout);
             },
         );
     });
@@ -264,3 +256,18 @@ export const getStylesPath = async (): Promise<string> => {
 
     return path;
 };
+
+export const buildCommand = (
+  exe: string,
+  config: string,
+  path: string
+): ReadonlyArray<string> => {
+  const command: ReadonlyArray<string> = [exe, "--no-exit"];
+  if (config !== "") {
+    command.concat(["--config", config]);
+  }
+
+  command.concat(["--output", "JSON", path]);
+  return command;
+};
+

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -261,13 +261,22 @@ export const buildCommand = (
   exe: string,
   config: string,
   path: string
-): ReadonlyArray<string> => {
-  const command: ReadonlyArray<string> = [exe, "--no-exit"];
-  if (config !== "") {
-    command.concat(["--config", config]);
-  }
+): Array<string> => {
+    const configuration = vscode.workspace.getConfiguration();
 
-  command.concat(["--output", "JSON", path]);
-  return command;
+    let command: Array<string> = [exe, "--no-exit"];
+    if (config !== "") {
+        command = command.concat(["--config", config]);
+    }
+
+    let minAlertLevel: string = configuration.get<string>(
+        "vale.valeCLI.minAlertLevel", "");
+
+    if (minAlertLevel !== "") {
+        command = command.concat(["--minAlertLevel", minAlertLevel]);
+    }
+
+    command = command.concat(["--output", "JSON", path]);
+    return command;
 };
 

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -270,9 +270,9 @@ export const buildCommand = (
     }
 
     let minAlertLevel: string = configuration.get<string>(
-        "vale.valeCLI.minAlertLevel", "");
+        "vale.valeCLI.minAlertLevel", "inherited");
 
-    if (minAlertLevel !== "") {
+    if (minAlertLevel !== "inherited") {
         command = command.concat(["--minAlertLevel", minAlertLevel]);
     }
 


### PR DESCRIPTION
This PR adds support for the `--minAlertLevel` flag by doing two things:

1. We now call a `buildCommand` utility function, which will allow us to add other flags in the future with minimal changes.

2. It splits up the existing `configLocation` logic into two cases: manually provided (which fails explicitly) and the default search process (which fails silently since a missing `.vale.ini` isn't necessarily an error in VS Code).

Closes #24.