### PR TITLE
Add `View Folder Report` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Add words and phrases to your active Vocab through the in-editor context menu.
 
 Jump to your active Vocab files directly from the Command Palette.
 
+### Folder Reports (Vale Server only)
+
+Use the `Vale: View Folder Report` command to generate a [report for the active folder](https://docs.errata.ai/vale-server/gui#summary).
+
 ## Settings
 
 The extension offers a number of settings and configuration options (_Preferences > Extensions > Vale_), which are split into three groups: `Vale > Core` (Vale and Vale Server), `Vale > Server` (Vale Server only), and `Vale > Vale CLI` (Vale only).

--- a/package.json
+++ b/package.json
@@ -47,7 +47,12 @@
 				"command": "vale.openReject",
 				"category": "Vale",
 				"title": "Open Vocab File (reject)"
-			}
+      },
+      {
+        "command": "vale.doSummary",
+        "category": "Vale",
+        "title": "View Folder Report"
+      }
 		],
 		"menus": {
 			"editor/context": [
@@ -74,7 +79,12 @@
 					"command": "vale.openReject",
 					"category": "Vale",
 					"when": "!config.vale.core.useCLI"
-				},
+        },
+        {
+          "command": "vale.doSummary",
+          "category": "Vale",
+          "when": "!config.vale.core.useCLI"
+        },
 				{
 					"command": "vale.addToAccept",
 					"category": "Vale",

--- a/src/features/vsCommands.ts
+++ b/src/features/vsCommands.ts
@@ -17,9 +17,27 @@ export default function InitCommands(subscriptions: vscode.Disposable[]) {
     vscode.commands.registerCommand("vale.addToReject", addToReject),
 
     vscode.commands.registerCommand("vale.openAccept", openAccept),
-    vscode.commands.registerCommand("vale.openReject", openReject)
+    vscode.commands.registerCommand("vale.openReject", openReject),
+
+    vscode.commands.registerCommand("vale.doSummary", doSummary)
   );
 }
+
+const doSummary = async () => {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    return;
+  }
+
+  let server: string = vscode.workspace
+    .getConfiguration()
+    .get("vale.server.serverURL", "http://localhost:7777");
+
+  let name = path.dirname(editor.document.fileName);
+  let link = server + `/summary.html?path=${name}`;
+
+  vscode.env.openExternal(vscode.Uri.parse(link));
+};
 
 const addToAccept = async () => {
   await addToVocab("accept");


### PR DESCRIPTION
This adds a new command to interface with Vale Server's new report-generation feature (coming in v1.9).

It allows you to view a report based custom metrics (see https://github.com/errata-ai/vale-server/issues/37). Here's an example:

![screely-1605942160606](https://user-images.githubusercontent.com/8785025/99870108-44368300-2b85-11eb-88dd-669f9ffa317b.png)

This command will open a report for the current file's parent folder.
