### PR TITLE
Create our own `OUTPUT` panel

### DIFF
--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -118,6 +118,9 @@ export default class ValeServerProvider implements vscode.CodeActionProvider {
     let body = JSON.parse(contents.toString());
     if (body.Code && body.Text) {
       this.logger.appendLine(body.Text);
+      if (body.Path) {
+        this.logger.appendLine(body.Path);
+      }
       return;
     }
 

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -152,8 +152,12 @@ export const runInWorkspace = (
       command[0],
       command.slice(1),
       { cwd, maxBuffer },
-      (error, stdout) => {
-        resolve(stdout);
+      (error, stdout, stderr) => {
+        if (error) {
+          resolve(stderr);
+        } else {
+          resolve(stdout);
+        }
       }
     );
   });


### PR DESCRIPTION
This implements our own entry in the `OUTPUT` panel and logs Vale's new runtime errors (https://github.com/errata-ai/vale/issues/238) there.

Here's an example:

![Screen Shot 2020-11-21 at 1 37 24 PM](https://user-images.githubusercontent.com/8785025/99888499-33782280-2c02-11eb-9160-e5c218a30049.png)
