### PR TITLE
Create publishing action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    tags:
+      - "*"
+
+- name: Publish to Open VSX Registry
+  uses: HaaLeo/publish-vscode-extension@v0
+  id: publishToOpenVSX
+  with:
+    pat: ${{ secrets.OPEN_VSX_TOKEN }}
+- name: Publish to Visual Studio Marketplace
+  uses: HaaLeo/publish-vscode-extension@v0
+  with:
+    pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+    registryUrl: https://marketplace.visualstudio.com
+    extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+    packagePath: ''


### PR DESCRIPTION
I started by addressing #28 and then digging in their docs realised we could publish new versions to both marketplaces with one action. But I appear to have lost some access levels @jdkato and can't create the required secrets needed in this action, or I can share the openvsx one with you…