### PR TITLE
Add Vale Install and Setup Script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,46 @@ As of **v0.10.0**, the extension supports both [Vale](https://github.com/errata-
 
 4. restart VS Code (recommended).
 
+#### Automatically Install and Setup Vale on Linux
+
+Simply run this script to install vale into your home directly with the Microsoft and write-good style guides. Copy the `.vale.ini` file into the root of your working directory:
+
+```shell
+#!/bin/bash
+
+# Download and extract binary (note maybe use latest and forget check?)
+
+curl -LOf https://github.com/errata-ai/vale/releases/download/v2.6.6/vale_2.6.6_Linux_64-bit.tar.gz
+echo "d585f2ff2e577f83eb21d9271dbade317c87e0dd45945417ea8652d4fb94dc0ad45403e96b55bcab8590a012d292194dbeac719b65c95d5bc54231d6698be3d9  vale_2.6.6_Linux_64-bit.tar.gz" |
+    sha512sum --check
+tar -C ~/bin/ -xf vale_2.6.6_Linux_64-bit.tar.gz --no-anchored 'vale'
+
+# Download style guides and extract (you could ask the user which ones?)
+
+curl -LOf https://github.com/errata-ai/Microsoft/releases/latest/download/Microsoft.zip
+curl -LOf https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip
+
+unzip Microsoft.zip -d ~/bin/styles
+unzip write-good.zip -d ~/bin/styles
+
+# Create dirs and settings files
+
+mkdir -p ~/bin/styles/Vocab/tech-blogging && touch ~/bin/styles/Vocab/tech-blogging/{accept.txt,reject.txt}
+
+# Clean up
+
+rm Microsoft.zip write-good.zip vale_2.6.6_Linux_64-bit.tar.gz
+```
+`.vale.ini`
+```shell
+StylesPath = /home/YOUR-USER-NAME/bin/styles
+
+Vocab = tech-blogging
+
+[*.md]
+BasedOnStyles = Vale, Microsoft, write-good
+```
+
 ## Features
 
 ### Detailed Problems View


### PR DESCRIPTION
I was pretty confused about how to install and use vale in VS Code. It took an evening to work it out, and in the process, I made a script to automate installation and setup.

I thought I would open a pull request just to give you the inspiration to add something like it to the vale-vscode README. I think this extension is amazing, but how to install and set it up is very confusing and not even mentioned in this repo.

Ideally, this extension should install the correct binary itself. Here is an extension that does that: https://github.com/timonwong/vscode-shellcheck

