### PR TITLE
Do not run Vale on out-of-workspace files when ${workspaceFolder} is used in settings.

### DIFF
--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -64,6 +64,11 @@ export default class ValeServerProvider implements vscode.CodeActionProvider {
 
     const binaryLocation = utils.readBinaryLocation(file);
     const configLocation = utils.readFileLocation(file);
+    if (binaryLocation == null || configLocation == null) {
+      // `file` is not part of the workspace, so we could not resolve a workspace-relative path. Ignore this file.
+      return;
+    }
+
     // There are two cases we need to handle here:
     //
     // (1) If we're given an explicit value for `--config`, then we should

--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -62,8 +62,8 @@ export default class ValeServerProvider implements vscode.CodeActionProvider {
   private async runVale(file: vscode.TextDocument) {
     const folder = path.dirname(file.fileName);
 
-    const binaryLocation = utils.readBinaryLocation(file);
-    const configLocation = utils.readFileLocation(file);
+    const binaryLocation = utils.readBinaryLocation(this.logger, file);
+    const configLocation = utils.readFileLocation(this.logger, file);
     if (binaryLocation == null || configLocation == null) {
       // `file` is not part of the workspace, so we could not resolve a workspace-relative path. Ignore this file.
       return;

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 
 // If `customPath` contains `${workspaceFolder}`, replaces it with the workspace that `file` comes from.
 // Return `null` if `customPath` contains `${workspaceFolder}` and `file` is _not_ part of the workspace.
-function replaceWorkspaceFolder(customPath: string, file: vscode.TextDocument): string | null {
+function replaceWorkspaceFolder(logger: vscode.OutputChannel, customPath: string, file: vscode.TextDocument): string | null {
   customPath = path.normalize(customPath);
   const workspaceFolder = vscode.workspace.getWorkspaceFolder(file.uri);
   if (workspaceFolder) {
@@ -17,25 +17,26 @@ function replaceWorkspaceFolder(customPath: string, file: vscode.TextDocument): 
       workspaceFolder.uri.fsPath
     );
   }
+  logger.appendLine(`Not running Vale on file '${file.uri}' as it is not contained within the workspace`);
   return null;
 }
 
-export const readBinaryLocation = (file: vscode.TextDocument): string | null => {
+export const readBinaryLocation = (logger: vscode.OutputChannel, file: vscode.TextDocument): string | null => {
   const configuration = vscode.workspace.getConfiguration();
 
   let customBinaryPath = configuration.get<string>("vale.valeCLI.path");
   if (customBinaryPath) {
-    return replaceWorkspaceFolder(customBinaryPath, file);
+    return replaceWorkspaceFolder(logger, customBinaryPath, file);
   }
   return which.sync("vale");
 };
 
-export const readFileLocation = (file: vscode.TextDocument): string | null => {
+export const readFileLocation = (logger: vscode.OutputChannel, file: vscode.TextDocument): string | null => {
   const configuration = vscode.workspace.getConfiguration();
 
   let customConfigPath = configuration.get<string>("vale.valeCLI.config");
   if (customConfigPath) {
-    return replaceWorkspaceFolder(customConfigPath, file);
+    return replaceWorkspaceFolder(logger, customConfigPath, file);
   }
   return "";
 };

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -6,38 +6,36 @@ import { execFile } from "child_process";
 
 import * as vscode from "vscode";
 
-export const readBinaryLocation = (file: vscode.TextDocument) => {
+// If `customPath` contains `${workspaceFolder}`, replaces it with the workspace that `file` comes from.
+// Return `null` if `customPath` contains `${workspaceFolder}` and `file` is _not_ part of the workspace.
+function replaceWorkspaceFolder(customPath: string, file: vscode.TextDocument): string | null {
+  customPath = path.normalize(customPath);
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(file.uri);
+  if (workspaceFolder) {
+    return customPath.replace(
+      "${workspaceFolder}",
+      workspaceFolder.uri.fsPath
+    );
+  }
+  return null;
+}
+
+export const readBinaryLocation = (file: vscode.TextDocument): string | null => {
   const configuration = vscode.workspace.getConfiguration();
 
   let customBinaryPath = configuration.get<string>("vale.valeCLI.path");
   if (customBinaryPath) {
-    customBinaryPath = path.normalize(customBinaryPath);
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(file.uri);
-    if (workspaceFolder) {
-      customBinaryPath = customBinaryPath.replace(
-        "${workspaceFolder}",
-        workspaceFolder.uri.fsPath
-      );
-    }
-    return customBinaryPath;
+    return replaceWorkspaceFolder(customBinaryPath, file);
   }
   return which.sync("vale");
 };
 
-export const readFileLocation = (file: vscode.TextDocument) => {
+export const readFileLocation = (file: vscode.TextDocument): string | null => {
   const configuration = vscode.workspace.getConfiguration();
 
   let customConfigPath = configuration.get<string>("vale.valeCLI.config");
   if (customConfigPath) {
-    customConfigPath = path.normalize(customConfigPath);
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(file.uri);
-    if (workspaceFolder) {
-      customConfigPath = customConfigPath.replace(
-        "${workspaceFolder}",
-        workspaceFolder.uri.fsPath
-      );
-    }
-    return customConfigPath;
+    return replaceWorkspaceFolder(customConfigPath, file);
   }
   return "";
 };


### PR DESCRIPTION
_Hey all! This is my first contribution to this project. Please let me know if you need me to make any changes._

Do not run Vale on out-of-workspace files when ${workspaceFolder} is used in settings.

Fixes a bug where Vale throws multiple errors whenever you do this.

## Problem

If you configure a `${workspaceFolder}`-relative path to `vale.ini` and open a Markdown file that is outside of the current workspace, Vale displays the following errors:

```
There was an error running Vale TypeError [ERR_INVALID_ARG_TYPE]: The "file" argument must be of type string. Received type undefined.
```

```
[Vale]: '${workspaceFolder}/docs/vale/.vale.ini' does not exist.
```

## Expected Behavior

Vale should silently _ignore_ any files that are not part of the current workspace.

## Reproducing

I've put together a workspace that demonstrates the issue. `README.md` details how to reproduce.

https://drive.google.com/file/d/17Jje6njhzFVfFdTPdosARIjf6a__7Pw_/view?usp=sharing