### PR TITLE
NLP integration

### DIFF
--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as which from "which";
 import * as fs from "fs";
 import * as request from "request-promise-native";
-import { execFile } from "child_process";
+import { execFile, ChildProcess } from "child_process";
 
 import * as vscode from "vscode";
 

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as which from "which";
 import * as fs from "fs";
 import * as request from "request-promise-native";
-import { execFile, ChildProcess } from "child_process";
+import { execFile } from "child_process";
 
 import * as vscode from "vscode";
 


### PR DESCRIPTION
This is the start of the NLP integration discussed in #56.

I've dropped the idea of creating a standalone executable in favor of simply publishing an package (https://pypi.org/project/nlpapi/) for now&mdash;users will need to run `$ pip install nlpapi` for this to work.

This is still a WIP, though. I'm going to publish a new Vale style based on [alex](https://github.com/get-alex/alex) that showcases how this can be used soon.