### PR TITLE
Switch back setting internal id to vale.valeCLI.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ The extension offers a number of settings and configuration options (_Preference
     }
     ```
 
-- `vale.path` (default: `null`): Absolute path to the Vale binary. Use the predefined [`${workspaceFolder}`](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) variable to reference a non-global binary. (**NOTE**: On Windows you can use '/' and can omit `.cmd` in the path value.)
+- `vale.valeCLI.path` (default: `null`): Absolute path to the Vale binary. Use the predefined [`${workspaceFolder}`](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) variable to reference a non-global binary. (**NOTE**: On Windows you can use '/' and can omit `.cmd` in the path value.)
 
     **Example**
 
     ```jsonc
     {
       // You can use ${workspaceFolder} it will be replaced by workspace folder path
-      "vale.path": "${workspaceFolder}/node_modules/.bin/vale"
+      "vale.valeCLI.path": "${workspaceFolder}/node_modules/.bin/vale"
 
       // or use some absolute path
-      "vale.path": "/some/path/to/vale"
+      "vale.valeCLI.path": "/some/path/to/vale"
     }
     ```
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 					"default": null,
 					"description": "Absolute path to a Vale config file. If not specified, the default search process will be used (relative to the current file)."
 				},
-				"vale.path": {
+				"vale.valeCLI.path": {
 					"scope": "resource",
 					"type": "string",
 					"default": null,


### PR DESCRIPTION
The interest of switching back is that it will avoid end-users having a
setting marked as invalid when opening the setting file. (or to
implement a migration of settings)

fixes #90

another advanateg is that ti will keep a group for Vale CLI binary which will be useful for implementing https://github.com/errata-ai/vale-vscode/issues/75