### PR TITLE
Temporarily disabled actions

### DIFF
--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -144,6 +144,13 @@ export default class ValeProvider implements vscode.CodeActionProvider {
     let diagnostic: vscode.Diagnostic = context.diagnostics[0];
     let actions: vscode.CodeAction[] = [];
 
+    return actions;
+
+    /* TODO: This needs more work / testing.
+    if (diagnostic === undefined) {
+      return actions;
+    }
+
     let key = `${diagnostic.message}-${diagnostic.range}`;
     let alert = this.alertMap[key];
 
@@ -166,7 +173,7 @@ export default class ValeProvider implements vscode.CodeActionProvider {
     };
 
     actions.push(action);
-    return actions;
+    return actions; */
   }
 
   private runCodeAction(


### PR DESCRIPTION
I think the problem was that the check

```ts
if (diagnostic === undefined || this.useCLI) {
    return actions;
}
```

was removed *entirely* in v0.15.0 when `this.useCLI` was the only part that needed to be removed.

This has proved difficult for me to debug, though, because I don't use this extension regularly and it doesn't seem to break in debug mode (even when the error messages appear).