### PR TITLE
Allow to disable warning dialog for unsaved files when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 					],
 					"markdownDescription": "Defines from which level of errors and above to display in the problems output."
 				},
-        "vale.doNotShowAgainWarningForFileToBeSavedBeforeLinting": {
+        "vale.doNotShowWarningForFileToBeSavedBeforeLinting": {
           "type": "boolean",
           "default": false,
           "description": "Do not show warning dialog that a file must be saved to have linting."

--- a/package.json
+++ b/package.json
@@ -60,7 +60,12 @@
 						"Sets `minAlertLevel` to `error`, overriding any configuration files."
 					],
 					"markdownDescription": "Defines from which level of errors and above to display in the problems output."
-				}
+				},
+        "vale.doNotShowAgainWarningForFileToBeSavedBeforeLinting": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do not show warning dialog that a file must be saved to have linting."
+        }
 			}
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "vale.doNotShowWarningForFileToBeSavedBeforeLinting": {
           "type": "boolean",
           "default": false,
-          "description": "Do not show warning dialog that a file must be saved to have linting."
+          "description": "Do not show warning dialog that a file must be saved to be linted."
         }
 			}
 		}

--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -18,7 +18,7 @@ export default class ValeProvider implements vscode.CodeActionProvider {
   private logger!: vscode.OutputChannel;
 
   private async doVale(textDocument: vscode.TextDocument) {
-    if (!utils.isElligibleDocument(textDocument)) {
+    if (!await utils.isElligibleDocument(textDocument)) {
       return;
     }
 

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -96,7 +96,7 @@ export const isElligibleDocument = async (document: vscode.TextDocument): Promis
       abortAndDoNotShowAgain
     );
     if (choice === abortAndDoNotShowAgain) {
-      await config.update('doNotShowAgainWarningForFileToBeSavedBeforeLinting', true, true);
+      await config.update('doNotShowWarningForFileToBeSavedBeforeLinting', true, true);
     }
     return false;
   }

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -85,7 +85,7 @@ export const toTitle = (alert: IValeErrorJSON, suggestion: string): string => {
 export const isElligibleDocument = async (document: vscode.TextDocument): Promise<boolean> => {
   if (document.isDirty) {
     const config = vscode.workspace.getConfiguration('vale');
-    const shouldIgnore = config.get<boolean>('doNotShowAgainWarningForFileToBeSavedBeforeLinting') === true;
+    const shouldIgnore = config.get<boolean>('doNotShowWarningForFileToBeSavedBeforeLinting') === true;
     if (shouldIgnore) {
       return false;
     }


### PR DESCRIPTION
![doNotShowDaialogAgain](https://user-images.githubusercontent.com/1105127/189298090-81e58591-7bdd-4875-896c-00dc07ab65ea.gif)

fixes #101 
