### PR TITLE
Add a setting for where readability problems are displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,23 @@
           "type": "boolean",
           "default": false,
           "description": "Do not show warning dialog that a file must be saved to be linted."
+        },
+        "vale.readabilityProblemLocation": {
+          "type": "string",
+          "enum": [
+            "status",
+            "inline",
+            "both"
+          ],
+          "default": "status",
+          "markdownEnumDescriptions": [
+            "Displays readability problems in the status bar.",
+            "Displays readability problems inline with other problems.",
+            "Displays readability problems both in the status bar and inline in the file."
+          ],
+          "markdownDescription": "Determines where file-level readability problems are displayed."
         }
+
 			}
 		}
 	},

--- a/src/features/vsProvider.ts
+++ b/src/features/vsProvider.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 
 import * as utils from "./vsUtils";
+import { getReadabilityProblemLocation } from "./vsUtils";
 
 export default class ValeProvider implements vscode.CodeActionProvider {
   private diagnosticCollection!: vscode.DiagnosticCollection;
@@ -103,14 +104,20 @@ export default class ValeProvider implements vscode.CodeActionProvider {
       return;
     }
 
+    const readabilityProblemLocation = getReadabilityProblemLocation()
     this.readabilityStatus.hide();
+
     for (let key in body) {
       const alerts = body[key];
       for (var i = 0; i < alerts.length; ++i) {
-        if (alerts[i].Match === "") {
+        const isReadabilityProblem = alerts[i].Match === ""
+
+        if (isReadabilityProblem && readabilityProblemLocation !== "inline") {
           var readabilityMessage = alerts[0].Message;
           this.updateStatusBarItem(readabilityMessage);
-        } else {
+        }
+
+        if (!isReadabilityProblem || readabilityProblemLocation !== "status") {
           let diagnostic = utils.toDiagnostic(
             alerts[i],
             this.stylesPath,

--- a/src/features/vsTypes.ts
+++ b/src/features/vsTypes.ts
@@ -30,3 +30,8 @@ interface IValeErrorJSON {
   readonly Span: [number, number];
   readonly Severity: ValeSeverity;
 }
+
+/**
+ * Where to display file-level readability problems.
+ */
+type ValeReadabilityProblemLocation = "both" | "inline" | "status";

--- a/src/features/vsUtils.ts
+++ b/src/features/vsUtils.ts
@@ -246,3 +246,12 @@ export const buildCommand = (
   command = command.concat(["--output", "JSON", path]);
   return command;
 };
+
+export const getReadabilityProblemLocation = (): ValeReadabilityProblemLocation => {
+  const configuration = vscode.workspace.getConfiguration();
+
+  return configuration.get<ValeReadabilityProblemLocation>(
+    "vale.readabilityProblemLocation",
+    "status"
+  );
+}


### PR DESCRIPTION
Readability problems (which affect the entire file, rather than a specific matched text) were moved from the inline problems list to the status bar in https://github.com/errata-ai/vale-vscode/pull/18. 

That PR calls out that a setting to control this behavior might be desirable. I prefer to have the readability problems listed inline with all the other problems, so I don't have multiple places to check for a particular file.

This adds a new setting, vale.readabilityProblemLocation with three options: 
- "status" (the current behavior, and the default),
- "inline" (display with other problems), and
- "both"

Test plan:
1. Configured .vale.ini with `Readability.ColemanLiau = YES`
2. Copied violating Markdown file file from https://github.com/errata-ai/readability/blob/main/testdata/ColemanLiau/test.md.
3. Verified behavior with these settings in settings.json:
  a. none, observed current behavior (problem in status bar)
  b. `"vale.readabilityProblemLocation": "inline"`, observed problem reported inline
  c. `"vale.readabilityProblemLocation": "status"`, observed current behavior (problem in status bar)
  d. `"vale.readabilityProblemLocation": "both"`, observed problem reported both in status bar and inline